### PR TITLE
Remove apis.google.com from block list

### DIFF
--- a/.hosts/basic.txt
+++ b/.hosts/basic.txt
@@ -10,7 +10,6 @@
 127.0.0.1 akamaiedge.net
 127.0.0.1 akamaitechnologies.com
 127.0.0.1 analytic-google.com
-127.0.0.1 apis.google.com
 127.0.0.1 clients1.google.com
 127.0.0.1 doubleclick.net
 127.0.0.1 dts.innovid.com


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No

## Description

The problem is that some tools like keep.google.com stop working at all with this domain banned.

Expected:
1. Domain keep.google.com is accessible

Actual:
1. Domain keep.google.com is not accessible


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote unit tests for my code _(if tests is required for my changes)_
- [ ] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
