### PR TITLE
Handler panic fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog][keepachangelog] and this project adheres to [Semantic Versioning][semver].
 
+## v4.0.1
+
+### Fixed
+
+- Mistake inside HTTP script generation handler (it caused handler panic when "excludes list" less than "sources list")
+
 ## v4.0.0
 
 ### Changed

--- a/internal/pkg/http/handlers/generate/handler.go
+++ b/internal/pkg/http/handlers/generate/handler.go
@@ -137,7 +137,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) { //nolint:f
 	if len(params.excluded) > 0 {
 		h.writeComment(w, "Excluded hosts:")
 
-		for i := 0; i < len(params.sources); i++ {
+		for i := 0; i < len(params.excluded); i++ {
 			h.writeComment(w, fmt.Sprintf(" - %s", params.excluded[i]))
 		}
 	}

--- a/internal/pkg/http/handlers/generate/handler_test.go
+++ b/internal/pkg/http/handlers/generate/handler_test.go
@@ -118,6 +118,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 			"https%3A%2F%2Fmock%2Fad_servers.txt"+
 			",http://mock/hosts_adaway.txt"+
 			",http://non-existing-file.txt"+
+			",http://non-existing-file2.txt"+
 			"&excluded_hosts="+
 			"aaa.com"+
 			",bbb.org"+
@@ -132,6 +133,7 @@ func TestHandler_ServeHTTP(t *testing.T) {
 	assert.Regexp(t, `Cache.+miss.+http:\/\/mock\/hosts_adaway\.txt`, body)
 	assert.Regexp(t, `Cache.+miss.+https:\/\/mock\/ad_servers\.txt`, body)
 	assert.Regexp(t, `Source.+non-existing-file\.txt.+404`, body)
+	assert.Regexp(t, `Source.+non-existing-file2\.txt.+404`, body)
 	assert.Regexp(t, `(?sU)Excluded hosts.+aaa\.com.+bbb\.org.+localhost`, rr.Body.String())
 	assert.Contains(t, body, "/ip dns static")
 	assert.Equal(t, strings.Count(body, "add address=127.0.0.5 comment=\"foo\" disabled=no"), 1234)


### PR DESCRIPTION
## Description

### Fixed

- Mistake inside HTTP script generation handler (it caused handler panic when "excludes list" less than "sources list")

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote unit tests for my code _(if tests is required for my changes)_
- [x] I have made changes in `CHANGELOG.md` file

<!--

About your changes in `CHANGELOG.md`:

* Add new version header like `## v1.x.x` or `## UNRELEASED`, if it does not exists
* Add description under `added`/`changed`/`fixed` sections
* Add reference to closed issues `[#000]`
* Add link to issue in the end of document

-->
