### PR TITLE
Added parsing of long-int IPs in hosts files

### DIFF
--- a/pkg/hostsfile/parser.go
+++ b/pkg/hostsfile/parser.go
@@ -104,7 +104,7 @@ scan: // read content "line by line"
 				if w.count == 1 {
 					if (w.flag.HasFlag(wordWithDot) && validateIPv4(w.buf.Bytes())) ||
 						(w.flag.HasFlag(wordWithColon) && net.ParseIP(w.buf.String()) != nil) ||
-						(validateIPLong(w.buf.Bytes())) {
+						(validateIPLong(w.buf.String())) {
 						ip.Write(w.buf.Bytes())
 					}
 				} else {
@@ -169,8 +169,8 @@ func validateIPv4(s []byte) bool {
 }
 
 // validateIPLong address (0 - 4294967295).
-func validateIPLong(s []byte) bool {
-	f, err := strconv.ParseFloat(string(s), 64)
+func validateIPLong(s string) bool {
+	f, err := strconv.ParseFloat(s, 64)
 	if err != nil || f < 0 || f > 4294967295 {
 		return false
 	}

--- a/pkg/hostsfile/parser.go
+++ b/pkg/hostsfile/parser.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"io"
 	"net"
+	"strconv"
 )
 
 // Hostname validator generation (execute in linux shell) using <https://gitlab.com/opennota/re2dfa>:
@@ -102,7 +103,8 @@ scan: // read content "line by line"
 
 				if w.count == 1 {
 					if (w.flag.HasFlag(wordWithDot) && validateIPv4(w.buf.Bytes())) ||
-						(w.flag.HasFlag(wordWithColon) && net.ParseIP(w.buf.String()) != nil) {
+						(w.flag.HasFlag(wordWithColon) && net.ParseIP(w.buf.String()) != nil) ||
+						(validateIPLong(w.buf.Bytes())) {
 						ip.Write(w.buf.Bytes())
 					}
 				} else {
@@ -164,6 +166,16 @@ func validateIPv4(s []byte) bool {
 	}
 
 	return len(s) == 0
+}
+
+// validateIPLong address (0 - 4294967295).
+func validateIPLong(s []byte) bool {
+	f, err := strconv.ParseFloat(string(s), 64)
+	if err != nil || f < 0 || f > 4294967295 {
+		return false
+	}
+
+	return true
 }
 
 // dtoi converts decimal to integer. Returns number, characters consumed, success.

--- a/pkg/hostsfile/parser_test.go
+++ b/pkg/hostsfile/parser_test.go
@@ -151,13 +151,19 @@ broken line format
 next line with IP only (spaces and tabs after)
 0.0.0.0 		 		  	 	 		 	'
 
+0 min.long.integer.ip               # valid
+4294967295 max.long.integer.ip      # valid
+4294967296 too-big.long.integer.ip  # invalid
+-1 too-small.long.integer.ip        # invalid
+4294N67295 broken.long.integer.ip   # invalid
+
 the end
 `))
 
 	records, err := Parse(buf)
 	assert.NoError(t, err)
 
-	assert.Len(t, records, 9)
+	assert.Len(t, records, 11)
 
 	assert.Equal(t, "1.2.3.4", records[0].IP)
 	assert.Equal(t, "dns.google", records[0].Host)
@@ -195,4 +201,12 @@ the end
 	assert.Equal(t, "3.3.3.3", records[8].IP)
 	assert.Equal(t, "xn--e1aybc.xn--p1ai", records[8].Host)
 	assert.Nil(t, records[8].AdditionalHosts)
+
+	assert.Equal(t, "0", records[9].IP)
+	assert.Equal(t, "min.long.integer.ip", records[9].Host)
+	assert.Nil(t, records[7].AdditionalHosts)
+
+	assert.Equal(t, "4294967295", records[10].IP)
+	assert.Equal(t, "max.long.integer.ip", records[10].Host)
+	assert.Nil(t, records[7].AdditionalHosts)
 }


### PR DESCRIPTION
Added parsing of long-int IPs in hosts files to address the issue described in https://github.com/tarampampam/mikrotik-hosts-parser/issues/119